### PR TITLE
clear some code for supporting multi-peers in one instance

### DIFF
--- a/yabgp/api/v1.py
+++ b/yabgp/api/v1.py
@@ -49,16 +49,6 @@ def root():
     return flask.jsonify(intro)
 
 
-@blueprint.route('/peers', methods=['GET'])
-@auth.login_required
-@api_utils.log_request
-def peers():
-    """
-    Get all peers realtime running information, include basic configurations and fsm state.
-    """
-    return flask.jsonify(api_utils.get_peer_conf_and_state())
-
-
 @blueprint.route('/peer/<peer_ip>/state')
 @auth.login_required
 @api_utils.log_request
@@ -67,54 +57,6 @@ def peer(peer_ip):
     Get one peer's running information, include basic configurations and fsm state.
     """
     return flask.jsonify(api_utils.get_peer_conf_and_state(peer_ip))
-
-
-@blueprint.route('/peer/<peer_ip>/stop')
-@auth.login_required
-@api_utils.log_request
-def stop_peer(peer_ip):
-    try:
-        api_utils.close_bgp_connection(peer_ip)
-        return flask.jsonify({
-            'status': True
-        })
-    except Exception as e:
-        LOG.error(e)
-        return flask.jsonify({
-            'status': False
-        })
-
-
-@blueprint.route('/peer/<peer_ip>/start')
-@auth.login_required
-@api_utils.log_request
-def start_peer(peer_ip):
-    try:
-        api_utils.start_bgp_connection(peer_ip)
-        return flask.jsonify({
-            'status': True
-        })
-    except Exception as e:
-        LOG.error(e)
-        return flask.jsonify({
-            'status': False
-        })
-
-
-@blueprint.route('/peer/<peer_ip>/restart')
-@auth.login_required
-@api_utils.log_request
-def restart_peer(peer_ip):
-    try:
-        api_utils.restart_bgp_connection(peer_ip)
-        return flask.jsonify({
-            'status': True
-        })
-    except Exception as e:
-        LOG.error(e)
-        return flask.jsonify({
-            'status': False
-        })
 
 
 @blueprint.route('/peer/<peer_ip>/statistic')

--- a/yabgp/config.py
+++ b/yabgp/config.py
@@ -86,7 +86,7 @@ def get_bgp_config():
     # check bgp configuration from CLI input
     LOG.info('Try to load BGP configuration from CLI input')
     if CONF.bgp.local_as and CONF.bgp.remote_as and CONF.bgp.local_addr and CONF.bgp.remote_addr:
-        CONF.bgp.running_config[CONF.bgp.remote_addr] = {
+        CONF.bgp.running_config = {
             'remote_as': CONF.bgp.remote_as,
             'remote_addr': CONF.bgp.remote_addr,
             'local_as': CONF.bgp.local_as,
@@ -105,20 +105,6 @@ def get_bgp_config():
                 'remote': {}
             }
         }
-
-        LOG.info('Get BGP running configuration for peer %s', CONF.bgp.remote_addr)
-        for item in CONF.bgp.running_config[CONF.bgp.remote_addr]:
-            if item == 'capability':
-                LOG.info('capability local:')
-                for capa in CONF.bgp.running_config[CONF.bgp.remote_addr][item]['local']:
-                    LOG.info(
-                        '-- %s: %s',
-                        capa,
-                        CONF.bgp.running_config[CONF.bgp.remote_addr][item]['local'][capa])
-                continue
-
-            LOG.info("%s = %s", item, CONF.bgp.running_config[CONF.bgp.remote_addr][item])
-        return
     else:
         LOG.error('Please provide enough parameters!')
         sys.exit()


### PR DESCRIPTION
For one yabgp instance, we only maintain one BGP session (yabgp as a TCP client).

Signed-off-by: Peng Xiao <xiaoquwl@gmail.com>