### PR TITLE
improve flowspec support

### DIFF
--- a/doc/source/msg_format.rst
+++ b/doc/source/msg_format.rst
@@ -360,7 +360,7 @@ Value     Meaning
 [1, 73]   IPv4 Sr-policy
 [2, 1]    IPv6 Unicast
 [2, 128]  IPv6 MPLSVPN
-[25, 70]  EVPN
+[25, 70]  L2VPN EVPN
 ...       ...
 ========= ===
 
@@ -392,10 +392,39 @@ IPv4 FlowSpec
             "14": {
                 "afi_safi": [1, 133],
                 "nexthop": "",
-                "nlri": [{"1": "192.88.2.3/24", "2": "192.89.1.3/24"}]
+                "nlri": [
+                    {"1": "192.88.2.3/24", "2": "192.89.1.3/24", "5": "=80|=8080"},
+                    {"1": "192.88.5.3/24", "2": "192.89.2.3/24", "5": "=80|=8080"}
+                ]
             }
         }
     }
+
+The nlri contains filters and values, and the supported filters are:
+
+.. code-block:: python
+
+    BGPNLRI_FSPEC_DST_PFIX = 1  # RFC 5575
+    BGPNLRI_FSPEC_SRC_PFIX = 2  # RFC 5575
+    BGPNLRI_FSPEC_IP_PROTO = 3  # RFC 5575
+    BGPNLRI_FSPEC_PORT = 4  # RFC 5575
+    BGPNLRI_FSPEC_DST_PORT = 5  # RFC 5575
+    BGPNLRI_FSPEC_SRC_PORT = 6  # RFC 5575
+    BGPNLRI_FSPEC_ICMP_TP = 7  # RFC 5575
+    BGPNLRI_FSPEC_ICMP_CD = 8  # RFC 5575
+    BGPNLRI_FSPEC_TCP_FLAGS = 9  # RFC 5575
+    BGPNLRI_FSPEC_PCK_LEN = 10  # RFC 5575
+    BGPNLRI_FSPEC_DSCP = 11  # RFC 5575
+    BGPNLRI_FSPEC_FRAGMENT = 12  # RFC 5575
+
+The value format of each filter are: `BGPNLRI_FSPEC_DST_PFIX` and `BGPNLRI_FSPEC_SRC_PFIX` are prefixes format,
+others are integers, but in string format like:
+
+`=80` means equal to `80`
+
+`=80|=8080` means equal to 80 or 8080.
+
+`>=80|<40` means geater than 80 or equal to 80 or less than 40
 
 IPv4 Sr-policy
 """"""""""""""
@@ -574,7 +603,10 @@ IPv4 FlowSpec
         "attr":{
             "15": {
                 "afi_safi": [1, 133],
-                "withdraw": [{"1": "192.88.2.3/24", "2": "192.89.1.3/24"}]
+                "withdraw": [
+                    {"1": "192.88.2.3/24", "2": "192.89.1.3/24", "5": "=80|=8080"},
+                    {"1": "192.16.0.0/8", "6": "=8080"}
+                ]
             }
         }
     }
@@ -586,10 +618,6 @@ IPv4 Sr-policy
 
     {
         "attr":{
-            "1": 0,
-            "2": [],
-            "3": "192.168.5.5",
-            "5": 200,
             "15": {
                 "afi_safi": [1, 73],
                 "withdraw": {

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,6 +5,3 @@ six>=1.10.0
 coverage
 testrepository>=0.0.13
 testtools>=0.9.26
-
-# for coveralls.io web service
-coveralls

--- a/tools/Yabgp.postman_collection.json
+++ b/tools/Yabgp.postman_collection.json
@@ -1,47 +1,73 @@
 {
-	"variables": [],
 	"info": {
 		"name": "Yabgp",
-		"_postman_id": "2331b642-660a-c670-0032-f81410a58926",
+		"_postman_id": "5a1ab0f6-55a9-623f-8470-8240a5af9e11",
 		"description": "",
-		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
 			"name": "Peer Information",
-			"description": "",
 			"item": [
 				{
 					"name": "get one peer state",
 					"request": {
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/state",
 						"method": "GET",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							}
 						],
-						"body": {},
-						"description": ""
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/state",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"state"
+							]
+						}
 					},
 					"response": []
 				},
 				{
 					"name": "peer message statistic",
 					"request": {
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/statistic",
 						"method": "GET",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							}
 						],
-						"body": {},
-						"description": ""
+						"body": {
+							"mode": "raw",
+							"raw": ""
+						},
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/statistic",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"statistic"
+							]
+						}
 					},
 					"response": []
 				}
@@ -54,25 +80,36 @@
 				{
 					"name": "send route refresh",
 					"request": {
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/route-refresh",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"afi\": 1,\n    \"safi\": 1,\n    \"res\": 0\n}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/route-refresh",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"route-refresh"
+							]
+						}
 					},
 					"response": []
 				}
@@ -80,39 +117,65 @@
 		},
 		{
 			"name": "evpn",
-			"description": "",
 			"item": [
 				{
 					"name": "route type 1 update",
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"1\": 0, \n        \"2\": [], \n        \"5\": 100, \n        \"14\": {\n            \"afi_safi\": [25, 70],\n            \"nexthop\": \"10.75.44.254\",\n            \"nlri\": [{\n                \"type\": 1,\n                \"value\": {\n                    \"rd\": \"1.1.1.1:32867\",\n                    \"esi\": 0,\n                    \"eth_tag_id\": 100,\n                    \"label\": [10]\n                }\n            }]},\n        \"16\":[[1537, 0, 500]]\n}}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				},
@@ -121,32 +184,59 @@
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"1\": 0, \n        \"2\": [], \n        \"5\": 100, \n        \"14\": {\n            \"afi_safi\": [25, 70],\n            \"nexthop\": \"10.75.44.254\",\n            \"nlri\": [\n                {\n                    \"type\": 2,\n                    \"value\": {\n                        \"eth_tag_id\": 108,\n                        \"ip\": \"11.11.11.1\",\n                        \"label\": [0],\n                        \"rd\": \"172.17.0.3:2\",\n                        \"mac\": \"00-11-22-33-44-55\",\n                        \"esi\": 0}}]},\n        \"16\":[[1536, 1, 500]]\n}}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				},
@@ -155,32 +245,59 @@
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"1\": 0, \n        \"2\": [], \n        \"5\": 100, \n        \"14\": {\n            \"afi_safi\": [25, 70],\n            \"nexthop\": \"10.75.44.254\",\n            \"nlri\": [\n                {\n                    \"type\": 3,\n                    \"value\": {\n                        \"rd\": \"172.16.0.1:5904\",\n                        \"eth_tag_id\": 100,\n                        \"ip\": \"192.168.0.1\"\n                    }\n                }\n            ]\n        }\n}}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				},
@@ -189,32 +306,59 @@
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"1\": 0, \n        \"2\": [], \n        \"5\": 100, \n        \"14\": {\n            \"afi_safi\": [25, 70],\n            \"nexthop\": \"10.75.44.254\",\n            \"nlri\": [\n                {\n                    \"type\": 4,\n                    \"value\": {\n                        \"rd\": \"172.16.0.1:8888\",\n                        \"esi\": 0,\n                        \"ip\": \"192.168.0.1\"\n                    }\n                }\n            ]\n        },\n         \"16\":[[1538, \"00-11-22-33-44-55\"]]\n}}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				},
@@ -223,32 +367,59 @@
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [25, 70],\n            \"withdraw\": [{\n                \"type\": 1,\n                \"value\": {\n                    \"rd\": \"1.1.1.1:32867\",\n                    \"esi\": 0,\n                    \"eth_tag_id\": 100,\n                    \"label\": [10]\n                }\n            }]}\n}}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				},
@@ -257,32 +428,59 @@
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [25, 70],\n            \"withdraw\": [\n                {\n                    \"type\": 2,\n                    \"value\": {\n                        \"eth_tag_id\": 108,\n                        \"ip\": \"11.11.11.1\",\n                        \"label\": [0],\n                        \"rd\": \"172.17.0.3:2\",\n                        \"mac\": \"00-11-22-33-44-55\",\n                        \"esi\": 0}}]\n        }\n        }\n}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				},
@@ -291,32 +489,59 @@
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [25, 70],\n            \"withdraw\": [\n                {\n                    \"type\": 3,\n                    \"value\": {\n                        \"rd\": \"172.16.0.1:5904\",\n                        \"eth_tag_id\": 100,\n                        \"ip\": \"192.168.0.1\"\n                    }\n                }\n            ]\n        }\n}}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				},
@@ -325,32 +550,59 @@
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [25, 70],\n            \"withdraw\": [\n                {\n                    \"type\": 4,\n                    \"value\": {\n                        \"rd\": \"172.16.0.1:8888\",\n                        \"esi\": 0,\n                        \"ip\": \"192.168.0.1\"\n                    }\n                }\n            ]\n        }\n}}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				}
@@ -358,71 +610,246 @@
 		},
 		{
 			"name": "ipv4_flowspec",
-			"description": "",
 			"item": [
 				{
-					"name": "Send update ipv4 flowspec",
+					"name": "Send withdraw ipv4 flowspec",
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [1, 133], \n            \"withdraw\": [{\"1\": \"192.88.2.3/24\", \"2\": \"192.89.1.3/24\"}]\n        }\n    }\n}"
+							"raw": "{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [1, 133], \n            \"withdraw\": [\n            \t{\"1\": \"192.88.2.3/24\", \"2\": \"192.89.1.3/24\"},\n            \t{\"1\": \"192.88.4.3/24\", \"2\": \"192.89.2.3/24\"}\n            ]\n        }\n    }\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
 						},
 						"description": "if you want to withdraw the prefix we sent, you can use the same url and http method, just use the following as POST data.\n\n```\n{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [1, 133], \n            \"withdraw\": [{\"1\": \"192.88.2.3/24\", \"2\": \"192.89.1.3/24\"}]\n        }\n    }\n}\n```"
 					},
 					"response": []
 				},
 				{
-					"name": "Send withdraw  ipv4 flowspec",
+					"name": "Send update  ipv4 flowspec (rate limit)",
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							}
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"attr\":{\n        \"1\": 0, \n        \"2\": [], \n        \"5\": 100, \n        \"14\": {\n            \"afi_safi\": [1, 133], \n            \"nexthop\": \"\", \n            \"nlri\": [{\"1\": \"192.88.2.3/24\", \"2\": \"192.89.1.3/24\"}]\n        },\n        \"16\":[[32774, \"100:6250000\"]]\n    }\n}"
+							"raw": "{\n    \"attr\":{\n        \"1\": 0, \n        \"2\": [], \n        \"5\": 100, \n        \"14\": {\n            \"afi_safi\": [1, 133], \n            \"nexthop\": \"\", \n            \"nlri\": [\n            \t{\"1\": \"192.88.2.3/24\", \"2\": \"192.89.1.3/24\", \"3\":\"=17|=80|=1\"},\n            \t{\"1\": \"192.77.2.3/24\", \"2\": \"192.77.1.3/24\", \"5\": \"=80|=8080\"}]\n        },\n        \"16\":[[32774, \"100:6250000\"]]\n    }\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						},
+						"description": "if you want to withdraw the prefix we sent, you can use the same url and http method, just use the following as POST data.\n\n```\n{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [1, 133], \n            \"withdraw\": [{\"1\": \"192.88.2.3/24\", \"2\": \"192.89.1.3/24\"}]\n        }\n    }\n}\n```"
+					},
+					"response": []
+				},
+				{
+					"name": "Send update  ipv4 flowspec (redirect nexthop)",
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Basic YWRtaW46YWRtaW4="
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"attr\":{\n        \"1\": 0, \n        \"2\": [], \n        \"5\": 100, \n        \"14\": {\n            \"afi_safi\": [1, 133], \n            \"nexthop\": \"1.1.1.1\", \n            \"nlri\": [\n            \t{\"1\": \"192.88.2.3/24\", \"2\": \"192.89.1.3/24\", \"3\":\"=17|=80|=1\"},\n            \t{\"1\": \"192.77.2.3/24\", \"2\": \"192.77.1.3/24\", \"5\": \"=80|=8080\"}]\n        },\n        \"16\":[[2048, \"0.0.0.0\", 0]]\n    }\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						},
+						"description": "if you want to withdraw the prefix we sent, you can use the same url and http method, just use the following as POST data.\n\n```\n{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [1, 133], \n            \"withdraw\": [{\"1\": \"192.88.2.3/24\", \"2\": \"192.89.1.3/24\"}]\n        }\n    }\n}\n```"
+					},
+					"response": []
+				},
+				{
+					"name": "Send update  ipv4 flowspec (set dscp=12)",
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"type": "any"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Basic YWRtaW46YWRtaW4="
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"attr\":{\n        \"1\": 0, \n        \"2\": [], \n        \"5\": 100, \n        \"14\": {\n            \"afi_safi\": [1, 133], \n            \"nexthop\": \"\", \n            \"nlri\": [\n            \t{\"1\": \"192.88.2.3/24\", \"2\": \"192.89.1.3/24\", \"3\":\"=17|=80|=1\"},\n            \t{\"1\": \"192.77.2.3/24\", \"2\": \"192.77.1.3/24\", \"5\": \"=80|=8080\"}]\n        },\n        \"16\":[[32777, 12]]\n    }\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
 						},
 						"description": "if you want to withdraw the prefix we sent, you can use the same url and http method, just use the following as POST data.\n\n```\n{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [1, 133], \n            \"withdraw\": [{\"1\": \"192.88.2.3/24\", \"2\": \"192.89.1.3/24\"}]\n        }\n    }\n}\n```"
 					},
@@ -432,39 +859,65 @@
 		},
 		{
 			"name": "ipv4_labeled_unicast",
-			"description": "",
 			"item": [
 				{
 					"name": "send update ipv4",
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"1\": 0, \n        \"2\": [], \n        \"5\": 400, \n        \"14\": {\n            \"afi_safi\": [1, 4], \n            \"nexthop\": \"10.75.44.254\",\n            \"nlri\":[\n              {\"prefix\": \"34.1.41.0/24\", \"label\": [321]},\n              {\"prefix\": \"34.1.42.0/24\", \"label\": [322]}]\n    }\n  }\n}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				},
@@ -473,32 +926,59 @@
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [1, 4], \n            \"withdraw\":[\n              {\"prefix\": \"34.1.41.0/24\", \"label\": [321]},\n              {\"prefix\": \"34.1.42.0/24\", \"label\": [322]}]\n    }\n  }\n}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				}
@@ -506,37 +986,64 @@
 		},
 		{
 			"name": "ipv4_mpls_vpn",
-			"description": "",
 			"item": [
 				{
 					"name": "Send update ipv4 mpls vpn",
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"1\": 0, \n        \"2\": [], \n        \"5\": 100, \n        \"14\": {\n            \"afi_safi\": [1, 128],\n            \"nexthop\": {\"rd\": \"0:0\", \"str\": \"2.2.2.2\"},\n            \"nlri\": [\n                {\n                    \"label\": [25],\n                    \"rd\": \"100:100\",\n                    \"prefix\": \"11.11.11.11/32\"}]},\n        \"16\": [[2, \"2:2\"]]\n}}"
+						},
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
 						},
 						"description": "if you want to send withdraw\n\n```\n{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [1, 128],\n            \"withdraw\": [\n                {\n                    \"rd\": \"100:100\",\n                    \"prefix\": \"11.11.11.11/32\"}]}\n        }\n}\n```"
 					},
@@ -547,30 +1054,58 @@
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [1, 128],\n            \"withdraw\": [\n                {\n                    \"rd\": \"100:100\",\n                    \"prefix\": \"11.11.11.11/32\"}]}\n        }\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
 						},
 						"description": "if you want to send withdraw\n\n```\n{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [1, 128],\n            \"withdraw\": [\n                {\n                    \"rd\": \"100:100\",\n                    \"prefix\": \"11.11.11.11/32\"}]}\n        }\n}\n```"
 					},
@@ -580,28 +1115,39 @@
 		},
 		{
 			"name": "ipv4_unicast",
-			"description": "",
 			"item": [
 				{
 					"name": "send update ipv4 unicast",
 					"request": {
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\r\n    \"attr\":{\r\n        \"1\": 0, \r\n        \"2\": [[2,[1,2,3]]],\r\n        \"3\": \"192.0.2.1\",\r\n        \"5\": 500,\r\n        \"8\": [\"NO_EXPORT\",\"123:456\"]\r\n    },\r\n  \"nlri\":[\"172.20.1.0/24\",\"172.20.2.0/24\"]\r\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
 						},
 						"description": "## Attribute\n\n### AS_PATH = 2 \n\n```\n[[2,[1,2,3]]]\n```\nthis means AS PATH is `1 2 3`, origin AS is 3, and direct AS is 1.\n\n## Prefix\n\nprefixes contain in a list.\n```\n\"nlri\":[\"172.20.1.0/24\",\"172.20.2.0/24\"]\n```\n\nif you want to send withdraw message to withdraw this two prefixes, you can use\nthis post data:\n\n```\n{\n  \"withdraw\":[\"172.20.1.0/24\",\"172.20.2.0/24\"],\n  \"attr\": {},\n  \"nlri\": []\n}\n```"
 					},
@@ -612,30 +1158,58 @@
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n  \"withdraw\":[\"172.20.1.0/24\",\"172.20.2.0/24\"],\n  \"attr\": {},\n  \"nlri\": []\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
 						},
 						"description": "if you want to send withdraw message to withdraw this two prefixes, you can use\nthis post data:\n\n```\n{\n  \"withdraw\":[\"172.20.1.0/24\",\"172.20.2.0/24\"],\n  \"attr\": {},\n  \"nlri\": []\n}\n```"
 					},
@@ -645,39 +1219,65 @@
 		},
 		{
 			"name": "ipv4_sr-policy",
-			"description": "",
 			"item": [
 				{
 					"name": "send update",
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{ \n\"attr\":{ \n\"1\": 0, \n\"2\": [], \n\"3\": \"192.168.5.5\", \n\"5\": 200, \n\"8\": [\"NO_ADVERTISE\"], \n\"14\": { \n\"afi_safi\": [1, \n 73], \n\"nexthop\": \"192.168.5.5\", \n\"nlri\": { \n\"distinguisher\": 0, \n\"color\": 10, \n\"endpoint\": \"192.168.76.1\" \n} \n}, \n\"16\": [[258, \n \"10.75.195.199:00\"]], \n\"23\": { \n\"6\": 100, \n\"7\": 25102, \n\"128\": [ \n{ \n\"9\": 2, \n\"1\": [ \n{ \n\"1\": { \n\"label\": 5000 \n} \n}, \n{ \n\"1\": { \n\"label\": 4000, \n\"TC\": 0, \n\"S\": 0, \n\"TTL\": 255 \n} \n} \n] \n}, \n{ \n\"9\": 10, \n\"1\": [ \n{ \n\"1\": { \n\"label\": 2000 \n} \n}, \n{ \n\"3\": { \n\"node\": \"10.1.1.1\", \n\"SID\": { \n\"label\": 3000, \n\"TC\": 0, \n\"S\": 0, \n\"TTL\": 255 \n} \n} \n} \n] \n} \n] \n} \n} \n}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				},
@@ -686,32 +1286,59 @@
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{ \n\"attr\":{ \n\"1\": 0, \n\"2\": [], \n\"3\": \"192.168.5.5\", \n\"5\": 200, \n\"8\": [\"NO_ADVERTISE\"], \n\"15\": { \n\"afi_safi\": [1, \n 73], \n\"withdraw\": { \n\"distinguisher\": 0, \n\"color\": 10, \n\"endpoint\": \"192.168.76.1\" \n} \n} \n} \n}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				}
@@ -719,39 +1346,65 @@
 		},
 		{
 			"name": "ipv6_labeled_unicast",
-			"description": "",
 			"item": [
 				{
 					"name": "send update",
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"1\": 0, \n        \"2\": [], \n        \"5\": 400, \n        \"14\": {\n            \"afi_safi\": [1, 4], \n            \"nexthop\": \"10.75.44.254\",\n            \"nlri\":[\n              {\"label\": [91], \"prefix\": \"2001:2121::1/128\"},\n              {\"label\": [92], \"prefix\": \"::2001:2121:1:0/64\"}]\n    }\n  }\n}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				},
@@ -760,32 +1413,59 @@
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [1, 4], \n            \"withdraw\":[\n              {\"label\": [91], \"prefix\": \"2001:2121::1/128\"},\n              {\"label\": [92], \"prefix\": \"::2001:2121:1:0/64\"}]\n    }\n  }\n}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				}
@@ -793,39 +1473,65 @@
 		},
 		{
 			"name": "ipv6_mpls_vpn",
-			"description": "",
 			"item": [
 				{
 					"name": "Send update ipv6 mpls vpn",
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"1\": 0, \n        \"2\": [], \n        \"5\": 100, \n        \"14\": {\n            \"afi_safi\": [2, 128],\n            \"nexthop\": {\"rd\": \"100:12\", \"str\": \"::ffff:172.16.4.12\"},\n            \"nlri\": [\n                {\n                    \"label\": [54],\n                    \"rd\": \"100:12\",\n                    \"prefix\": \"2010:0:12:4::/64\"},\n                {\n                    \"label\": [55],\n                    \"rd\": \"100:12\",\n                    \"prefix\": \"2010:1:12::/64\"\n                }\n            ]},\n        \"16\": [[2, \"100:12\"]]\n}}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				},
@@ -834,32 +1540,59 @@
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							},
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\":{\n        \"15\": {\n            \"afi_safi\": [2, 128],\n            \"withdraw\": [\n                {\n                    \"label\": [54],\n                    \"rd\": \"100:12\",\n                    \"prefix\": \"2010:0:12:4::/64\"},\n                {\n                    \"label\": [55],\n                    \"rd\": \"100:12\",\n                    \"prefix\": \"2010:1:12::/64\"\n                }\n            ]}\n}}"
 						},
-						"description": ""
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
+						}
 					},
 					"response": []
 				}
@@ -867,37 +1600,64 @@
 		},
 		{
 			"name": "ipv6_unicast",
-			"description": "",
 			"item": [
 				{
 					"name": "send update ipv6 unicast",
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\": {\n                \"15\": {\n                    \"afi_safi\": [2, 1],\n                    \"withdraw\": [\"::2001:db8:2:2/64\", \"::2001:db8:2:1/64\", \"::2001:db8:2:0/64\"]}\n            },\n    \"nlri\":[],\n    \"withdraw\": []\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
 						},
 						"description": "if you want to withdraw the prefix we sent, you can use the same url and http method, just use the following as POST data.\n\n```\n{\n    \"attr\": {\n                \"15\": {\n                    \"afi_safi\": [2, 1],\n                    \"withdraw\": [\"::2001:db8:2:2/64\", \"::2001:db8:2:1/64\", \"::2001:db8:2:0/64\"]}\n            },\n    \"nlri\":[],\n    \"withdraw\": []\n}\n```"
 					},
@@ -908,30 +1668,58 @@
 					"request": {
 						"auth": {
 							"type": "basic",
-							"basic": {
-								"username": "admin",
-								"password": "admin",
-								"saveHelperData": true,
-								"showPassword": false
-							}
+							"basic": [
+								{
+									"key": "username",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "admin",
+									"type": "string"
+								},
+								{
+									"key": "saveHelperData",
+									"value": true,
+									"type": "boolean"
+								},
+								{
+									"key": "showPassword",
+									"value": false,
+									"type": "boolean"
+								}
+							]
 						},
-						"url": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
 						"method": "POST",
 						"header": [
 							{
 								"key": "Authorization",
-								"value": "Basic YWRtaW46YWRtaW4=",
-								"description": ""
+								"value": "Basic YWRtaW46YWRtaW4="
 							},
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"description": ""
+								"value": "application/json"
 							}
 						],
 						"body": {
 							"mode": "raw",
 							"raw": "{\n    \"attr\": {\n                \"1\": 0,\n                \"2\": [[2, [65502]]],\n                \"4\": 0,\n                \"14\": {\n                    \"afi_safi\": [2, 1],\n                    \"linklocal_nexthop\": \"fe80::c002:bff:fe7e:0\",\n                    \"nexthop\": \"2001:db8::2\",\n                    \"nlri\": [\"::2001:db8:2:2/64\", \"::2001:db8:2:1/64\", \"::2001:db8:2:0/64\"]}\n            },\n    \"nlri\":[],\n    \"withdraw\": []\n}"
+						},
+						"url": {
+							"raw": "http://{{host}}:{{port}}/v1/peer/{{peer}}/send/update",
+							"protocol": "http",
+							"host": [
+								"{{host}}"
+							],
+							"port": "{{port}}",
+							"path": [
+								"v1",
+								"peer",
+								"{{peer}}",
+								"send",
+								"update"
+							]
 						},
 						"description": "if you want to withdraw the prefix we sent, you can use the same url and http method, just use the following as POST data.\n\n```\n{\n    \"attr\": {\n                \"15\": {\n                    \"afi_safi\": [2, 1],\n                    \"withdraw\": [\"::2001:db8:2:2/64\", \"::2001:db8:2:1/64\", \"::2001:db8:2:0/64\"]}\n            },\n    \"nlri\":[],\n    \"withdraw\": []\n}\n```"
 					},

--- a/yabgp/common/flag.py
+++ b/yabgp/common/flag.py
@@ -1,0 +1,26 @@
+# Copyright 2015-2017 Cisco Systems, Inc.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+class ByteFlag(int):
+
+    FLAGS = ['']
+
+    def dict(self):
+        bit_list = []
+        for i in range(8):
+            bit_list.append((self >> i) & 1)
+        bit_list.reverse()
+        return dict(zip(self.FLAGS, bit_list[:len(self.FLAGS)]))

--- a/yabgp/message/attribute/mpreachnlri.py
+++ b/yabgp/message/attribute/mpreachnlri.py
@@ -238,8 +238,7 @@ class MpReachNLRI(Attribute):
                     except netaddr.core.AddrFormatError:
                         nexthop = ''
                     nlri_hex = b''
-                    for nlri in value['nlri']:
-                        nlri_hex += IPv4FlowSpec.construct(value=nlri)
+                    nlri_hex += IPv4FlowSpec.construct(value=value['nlri'])
                     if nlri_hex:
                         attr_value = struct.pack('!H', afi) + struct.pack('!B', safi) + \
                             struct.pack('!B', len(nexthop)) + nexthop + b'\x00' + nlri_hex

--- a/yabgp/message/attribute/mpunreachnlri.py
+++ b/yabgp/message/attribute/mpunreachnlri.py
@@ -143,8 +143,7 @@ class MpUnReachNLRI(Attribute):
                     if not nlri_list:
                         return None
                     nlri_hex = b''
-                    for nlri in nlri_list:
-                        nlri_hex += IPv4FlowSpec.construct(value=nlri)
+                    nlri_hex += IPv4FlowSpec.construct(value=nlri_list)
                     attr_value = struct.pack('!H', afi) + struct.pack('!B', safi) + nlri_hex
                     return struct.pack('!B', cls.FLAG) + struct.pack('!B', cls.ID) \
                         + struct.pack('!B', len(attr_value)) + attr_value

--- a/yabgp/tests/unit/message/attribute/nlri/test_ipv4_flowspec.py
+++ b/yabgp/tests/unit/message/attribute/nlri/test_ipv4_flowspec.py
@@ -22,16 +22,15 @@ from yabgp.message.attribute.nlri.ipv4_flowspec import IPv4FlowSpec
 class TestIPv4FlowSpec(unittest.TestCase):
 
     def test_parse(self):
-        pass
         raw_hex = '\x01\x18\x02\x02\x02\x02\x10\x03\x03\x03\x01\x00\x01\x2f\x01\x58' \
                   '\x01\x01\x01\x02\x01\x59\x81\x67\x05\x11\x1f\x92\x91\x1f\x93\x06\x01' \
                   '\x50\x11\x1f\x90\x11\x1f\x91\x11\x1f\x92\x91\x1f\x93\x07\x01\x02\x01' \
                   '\x03\x01\x05\x81\x06\x08\x81\x02\x09\x81\x28\x0a\x01\xfe\x03\xfe\xd5' \
                   '\x01\x2c\x0b\x01\x28\x81\x30\x0c\x81\x01'
         self.assertEqual(
-            {1: '2.2.2.0/24', 2: '3.3.0.0/16', 3: '=0 =47 =88 =1 =2 =89 =103', 5: '=8082 =8083',
-             6: '=80 =8080 =8081 =8082 =8083', 7: '=2 =3 =5 =6', 8: '=2', 9: '=40', 10: '=254 >=254&<=300',
-             11: '=40 =48', 12: '=1'}, IPv4FlowSpec.parse(raw_hex))
+            {1: '2.2.2.0/24', 2: '3.3.0.0/16', 3: '=0|=47|=88|=1|=2|=89|=103', 5: '=8082|=8083',
+             6: '=80|=8080|=8081|=8082|=8083', 7: '=2|=3|=5|=6', 8: '=2', 9: '=40', 10: '=254|>=254&<=300',
+             11: '=40|=48', 12: '=1'}, IPv4FlowSpec.parse(raw_hex))
 
     def test_parse_nlri_prefix(self):
         raw_hex = b'\x01\x18\x6e\x01\x01'
@@ -39,25 +38,25 @@ class TestIPv4FlowSpec(unittest.TestCase):
 
     def test_parse_nlri_packet_length(self):
         raw_hex = '\x0a\x01\xfe\x03\xfe\xd5\x01\x2c'
-        self.assertEqual({bgp_cons.BGPNLRI_FSPEC_PCK_LEN: '=254 >=254&<=300'}, IPv4FlowSpec.parse(raw_hex))
+        self.assertEqual({bgp_cons.BGPNLRI_FSPEC_PCK_LEN: '=254|>=254&<=300'}, IPv4FlowSpec.parse(raw_hex))
 
     def test_parse_nlri_ip_protocol(self):
         raw_hex = '\x03\x01\x00\x01\x2f\x01\x58\x01\x01\x01\x02\x01\x59\x81\x67'
-        self.assertEqual({bgp_cons.BGPNLRI_FSPEC_IP_PROTO: '=0 =47 =88 =1 =2 =89 =103'}, IPv4FlowSpec.parse(raw_hex))
+        self.assertEqual({bgp_cons.BGPNLRI_FSPEC_IP_PROTO: '=0|=47|=88|=1|=2|=89|=103'}, IPv4FlowSpec.parse(raw_hex))
 
     def test_parse_nlri_des_port(self):
         raw_hex = '\x05\x01\x50\x11\x1f\x90\x11\x1f\x91\x11\x1f\x92\x91\x1f\x93'
-        self.assertEqual({bgp_cons.BGPNLRI_FSPEC_DST_PORT: '=80 =8080 =8081 =8082 =8083'},
+        self.assertEqual({bgp_cons.BGPNLRI_FSPEC_DST_PORT: '=80|=8080|=8081|=8082|=8083'},
                          IPv4FlowSpec.parse(raw_hex))
 
     def test_parse_nlri_src_port(self):
         raw_hex = '\x06\x01\x50\x11\x1f\x90\x11\x1f\x91\x11\x1f\x92\x91\x1f\x93'
-        self.assertEqual({bgp_cons.BGPNLRI_FSPEC_SRC_PORT: '=80 =8080 =8081 =8082 =8083'},
+        self.assertEqual({bgp_cons.BGPNLRI_FSPEC_SRC_PORT: '=80|=8080|=8081|=8082|=8083'},
                          IPv4FlowSpec.parse(raw_hex))
 
     def test_parse_nlri_icmp_type(self):
         raw_hex = '\x07\x01\x02\x01\x03\x01\x05\x81\x06'
-        self.assertEqual({bgp_cons.BGPNLRI_FSPEC_ICMP_TP: '=2 =3 =5 =6'}, IPv4FlowSpec.parse(raw_hex))
+        self.assertEqual({bgp_cons.BGPNLRI_FSPEC_ICMP_TP: '=2|=3|=5|=6'}, IPv4FlowSpec.parse(raw_hex))
 
     def test_parse_nlri_icmp_code(self):
         raw_hex = '\x08\x81\x02'
@@ -68,11 +67,34 @@ class TestIPv4FlowSpec(unittest.TestCase):
         prefix_str = '192.85.2.0/24'
         self.assertEqual(prefix_bin, IPv4FlowSpec.construct_prefix(prefix_str))
 
+    def test_construct_operator_flag(self):
+        flag = {
+            'LEN': 1,
+            'EQ': 1,
+            'EOL': 1
+        }
+        self.assertEqual(0x81, IPv4FlowSpec.construct_operator_flag(flag))
+        flag = {
+            'EOL': 1,
+            'LEN': 2,
+            'AND': 1,
+            'LT': 1,
+            'EQ': 1
+        }
+        self.assertEqual(0xd5, IPv4FlowSpec.construct_operator_flag(flag))
+
+    def test_construct_operators(self):
+        operators = '=80|=8080|=8083'
+        operators_bin = b'\x01\x50\x11\x1f\x90\x91\x1f\x93'
+        self.assertEqual(operators_bin, IPv4FlowSpec.construct_operators(operators))
+
     def test_construct_nlri(self):
+        raw_hex = '\x0f\x05\x01\x50\x11\x1f\x90\x11\x1f\x91\x11\x1f\x92\x91\x1f\x93'
+        nlri_dict = {bgp_cons.BGPNLRI_FSPEC_DST_PORT: '=80|=8080|=8081|=8082|=8083'}
+        self.assertEqual(raw_hex, IPv4FlowSpec.construct_nlri(nlri_dict))
         nlri_bin = b'\x0a\x01\x18\xc0\x55\x02\x02\x18\xc0\x55\x01'
         nlri_list = {1: '192.85.2.0/24', 2: '192.85.1.0/24'}
         self.assertEqual(nlri_bin, IPv4FlowSpec.construct_nlri(nlri_list))
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
issue #52 

now flowspec support message like:

```python
{
    "attr":{
        "1": 0, 
        "2": [], 
        "5": 100, 
        "14": {
            "afi_safi": [1, 133], 
            "nexthop": "", 
            "nlri": [
            	{"1": "192.88.2.3/24", "2": "192.89.1.3/24", "3":"=17|=80|>=8000"},
            	{"1": "192.77.2.3/24", "2": "192.77.1.3/24", "5": "=80|=8080"}]
        },
        "16":[[32774, "100:6250000"]]
    }
}
```

filter value support `=`, `<`,`>`,`>=`,`<=`, and `|`