### PR TITLE
fix ExtDeprecationWarning: Importing flask.ext.httpauth is deprecated, use flask_httpauth instead.

### DIFF
--- a/yabgp/api/v1.py
+++ b/yabgp/api/v1.py
@@ -18,7 +18,7 @@
 import logging
 import time
 
-from flask.ext.httpauth import HTTPBasicAuth
+from flask_httpauth import HTTPBasicAuth
 from flask import Blueprint, request
 import flask
 from oslo_config import cfg


### PR DESCRIPTION
fix #92 

Signed-off-by: Peng Xiao <xiaoquwl@gmail.com>