### PR TITLE
fix object of type 'bytes' is not JSON serializable issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ Flask-HTTPAuth==2.5.0
 netaddr>=0.7.12
 future>=0.16.0
 pysubnettree==0.26
+simplejson==3.17.0

--- a/yabgp/handler/default_handler.py
+++ b/yabgp/handler/default_handler.py
@@ -1,6 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-import json
+
+# import json
+# replace with simplejson
+import simplejson as json
+
 import os
 import time
 import logging


### PR DESCRIPTION
 ERROR yabgp.handler.default_handler [-] Object of type bytes is not JSON serializable

raw message {'msg': {'attr': {1: 0, 2: [(2, [65001, 27418, 8100, 4826, 17477])], 3: '172.31.13.194', 5: 100, 8: ['4826:1000', '4826:5204', '4826:7000', '4826:52041', '8100:50', '17477:10100', '29761:50'], 9: '172.31.13.194', 10: ['172.31.51.169'], **128: b'0000ffdc4001010040020040050400000064'},** 'nlri': ['203.8.71.0/24', '203.56.122.0/24', '85.118.153.0/24'], 'withdraw': [], 'afi_safi': 'ipv4'}}

