### PR TITLE
Initial support for TCP Authentication Option

### DIFF
--- a/yabgp/agent/__init__.py
+++ b/yabgp/agent/__init__.py
@@ -78,6 +78,7 @@ def prepare_twisted_service(handler, reactor_thread_size=100):
         peeraddr=CONF.bgp.running_config['remote_addr'],
         afisafi=CONF.bgp.running_config['afi_safi'],
         md5=CONF.bgp.running_config['md5'],
+        tcp_authopt=CONF.bgp.running_config['tcp_authopt'],
         handler=handler
     )
     CONF.bgp.running_config['factory'] = bgp_peering

--- a/yabgp/config.py
+++ b/yabgp/config.py
@@ -80,6 +80,24 @@ BGP_PEER_CONFIG_OPTS = [
 
 CONF.register_cli_opts(BGP_PEER_CONFIG_OPTS, group='bgp')
 
+TCP_AUTHOPT_OPTS = [
+    cfg.IntOpt('send_id', default=0,
+               help='The remote BGP peer AS number'),
+    cfg.IntOpt('recv_id', default=0,
+               help='The Local BGP AS number'),
+    cfg.StrOpt('key',
+               help='The master key',
+               secret=True),
+    cfg.StrOpt('alg',
+               help='Algorithm (hmac-sha-1-96 or aes-128-cmac-96)',
+               default="hmac-sha-1-96"),
+    cfg.BoolOpt('include-options',
+                default=True,
+                help='include TCP options in MAC'),
+]
+
+CONF.register_cli_opts(TCP_AUTHOPT_OPTS, group='tcp_authopt')
+
 BGP_PEER_TIME_OPTS = [
     cfg.IntOpt('connect_retry_time',
                default=30,
@@ -117,6 +135,7 @@ def get_bgp_config():
             'local_as': CONF.bgp.local_as,
             'local_addr': CONF.bgp.local_addr,
             'md5': CONF.bgp.md5,
+            'tcp_authopt': CONF.tcp_authopt,
             'afi_safi': CONF.bgp.afi_safi,
             'capability': {
                 'local': {


### PR DESCRIPTION
This works with Linux patches from here:
https://github.com/cdleonard/linux/commits/tcp_authopt

Upstream RFC: https://www.notion.so/TCP-AuthOpt-b4c58f69d3eb44e48f7acd4997ec1e7e#f79df14201ee4619adaaa0524458c049

ABI is unstable so this shouldn't be merged but feedback is welcome.

Signed-off-by: Leonard Crestez <cdleonard@gmail.com>