### PR TITLE
Remove useless self-assignment

### DIFF
--- a/yabgp/tests/unit/message/attribute/test_tunnelencaps.py
+++ b/yabgp/tests/unit/message/attribute/test_tunnelencaps.py
@@ -129,7 +129,7 @@ class TestTunnelEncaps(unittest.TestCase):
             "0": "new",
             "15": 200
         }
-        data_hex = data_hex = b'\x0f\x02\xc8\x00'
+        data_hex = b'\x0f\x02\xc8\x00'
         self.assertEqual(data_hex, TunnelEncaps.construct(data_dict)[12:])
 
     def test_construct_policy_name(self):
@@ -137,7 +137,7 @@ class TestTunnelEncaps(unittest.TestCase):
             "0": "new",
             "129": "test"
         }
-        data_hex = data_hex = b'\x81\x00\x05\x00\x74\x65\x73\x74'
+        data_hex = b'\x81\x00\x05\x00\x74\x65\x73\x74'
         self.assertEqual(data_hex, TunnelEncaps.construct(data_dict)[12:])
 
     def test_construct_remote_endpoint_ipv4(self):


### PR DESCRIPTION
Tried using SonarQube, both bugs scanned were fixed.
But so far it has not been associated with CI, not sure if the scanner needs to be deployed independently.

<img width="1319" alt="image" src="https://user-images.githubusercontent.com/16861681/180244676-c69cb628-abbe-47f6-b621-c798bca90731.png">

<img width="1319" alt="image" src="https://user-images.githubusercontent.com/16861681/180244778-d7005497-caed-4520-b191-38efe1eff422.png">